### PR TITLE
Remove control code literals from source code

### DIFF
--- a/src/editor/core.cljs
+++ b/src/editor/core.cljs
@@ -67,16 +67,23 @@
         [pre post] (split-at x current-line)]
     (assoc-in state [:buffer y] (str (apply str (butlast pre)) (apply str post)))))
 
+(def ctrl-q (.fromCharCode js/String 17))
+(def ctrl-n (.fromCharCode js/String 14))
+(def ctrl-p (.fromCharCode js/String 16))
+(def ctrl-b (.fromCharCode js/String 2))
+(def ctrl-f (.fromCharCode js/String 6))
+(def ctrl-h (.fromCharCode js/String 8))
+
 (defn handle-input [{:keys [buffer cursor] :as state}]
-  (let [ch ((:raw-read core/*in*))]
-    (condp = ch
-      "" (core/exit 0)
-      "" (clamp-y (move-down state))
-      "" (clamp-y (move-up state))
-      "" (clamp-x (move-left state))
-      "" (clamp-x (move-right state))
-      "" ((comp move-left backspace) state)
-      ((comp move-right insert) state ch))))
+      (let [ch ((:raw-read core/*in*))]
+           (condp = ch
+             ctrl-q (core/exit 0)
+             ctrl-n (clamp-y (move-down state))
+             ctrl-p (clamp-y (move-up state))
+             ctrl-b (clamp-x (move-left state))
+             ctrl-f (clamp-x (move-right state))
+             ctrl-h ((comp move-left backspace) state)
+             ((comp move-right insert) state ch))))
 
 (defn editor [file-contents]
 

--- a/src/editor/core.cljs
+++ b/src/editor/core.cljs
@@ -75,15 +75,15 @@
 (def ctrl-h (.fromCharCode js/String 8))
 
 (defn handle-input [{:keys [buffer cursor] :as state}]
-      (let [ch ((:raw-read core/*in*))]
-           (condp = ch
-             ctrl-q (core/exit 0)
-             ctrl-n (clamp-y (move-down state))
-             ctrl-p (clamp-y (move-up state))
-             ctrl-b (clamp-x (move-left state))
-             ctrl-f (clamp-x (move-right state))
-             ctrl-h ((comp move-left backspace) state)
-             ((comp move-right insert) state ch))))
+  (let [ch ((:raw-read core/*in*))]
+    (condp = ch
+      ctrl-q (core/exit 0)
+      ctrl-n (clamp-y (move-down state))
+      ctrl-p (clamp-y (move-up state))
+      ctrl-b (clamp-x (move-left state))
+      ctrl-f (clamp-x (move-right state))
+      ctrl-h ((comp move-left backspace) state)
+      ((comp move-right insert) state ch))))
 
 (defn editor [file-contents]
 


### PR DESCRIPTION
Some editors, like IntelliJ, struggles displaying the control code literals.

Even "less" struggled showing ctrl-h.

Real editors like nano shows them correctly though.

This patch uses String.fromCharCode and the character codes instead of having the control codes written directly to the source code

IntelliJ

![control-codes-intellij](https://user-images.githubusercontent.com/375/30170895-b217b73e-93f0-11e7-9560-44c17a906b8d.PNG)

Nano

![control-codes-nano](https://user-images.githubusercontent.com/375/30171008-f9cef312-93f0-11e7-885b-4aaaf08b58a2.PNG)

Less

![control-codes-less](https://user-images.githubusercontent.com/375/30171013-fc601cdc-93f0-11e7-87cb-a28c77b6b789.PNG)
